### PR TITLE
simplify get_md_path()

### DIFF
--- a/src/instrument/utils/metadata.py
+++ b/src/instrument/utils/metadata.py
@@ -57,11 +57,7 @@ VERSIONS = dict(
 
 def get_md_path():
     """Get PersistentDict directory for RE metadata."""
-    path = iconfig.get("MD_PATH")
-    if path is None:
-        path = DEFAULT_MD_PATH
-    else:
-        path = pathlib.Path(path)
+    path = pathlib.Path(iconfig.get("MD_PATH"), DEFAULT_MD_PATH)
     logger.info("RunEngine metadata saved in directory: %s", str(path))
     return str(path)
 

--- a/src/instrument/utils/metadata.py
+++ b/src/instrument/utils/metadata.py
@@ -57,7 +57,7 @@ VERSIONS = dict(
 
 def get_md_path():
     """Get PersistentDict directory for RE metadata."""
-    path = pathlib.Path(iconfig.get("MD_PATH"), DEFAULT_MD_PATH)
+    path = pathlib.Path(iconfig.get("MD_PATH", DEFAULT_MD_PATH))
     logger.info("RunEngine metadata saved in directory: %s", str(path))
     return str(path)
 


### PR DESCRIPTION
Reduce the number of code lines here.  It's pretty common to use `pathlib.Path(pathlib.Path(text))`, the library probably shortcuts this anyway.